### PR TITLE
feat(sse) server sent events suport

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -51,3 +51,11 @@ routes:
         service: localhost:3000
         tag: users
         removeKeyMapping: false
+
+  - method: GET
+    route: /sse
+    service: localhost:3000
+    path: /sse
+    isSSE: true
+
+

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Route struct {
 	Service string         `mapstructure:"service"`
 	Mapping []RouteMapping `mapstructure:"mapping"`
 	Route   string         `mapstructure:"route"`
+	IsSSE   bool           `mapstructure:"isSSE,omitempty" yaml:"isSSE,omitempty"`
 }
 
 type BaseConfig struct {

--- a/internal/util/pathProtocol.go
+++ b/internal/util/pathProtocol.go
@@ -7,11 +7,9 @@ import (
 func PathProtocol(path string) (string, string) {
 	protocol := "http"
 	if strings.HasPrefix(path, "http://") {
-
 		path = strings.TrimPrefix(path, "http://")
 	} else if strings.HasPrefix(path, "https://") {
-
-		protocol = "https:"
+		protocol = "https"
 		path = strings.TrimPrefix(path, "https://")
 	}
 

--- a/makefile
+++ b/makefile
@@ -1,2 +1,7 @@
 run:
 	go run cmd/gateway/main.go
+
+# Run SSE test server
+sse-server:
+	@echo "Starting SSE test server on :3000/sse"
+	@go run test/sseServer/sse_server.go

--- a/test/sseServer/sse_client.html
+++ b/test/sseServer/sse_client.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SSE Test Client</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen p-8">
+    <div class="max-w-3xl mx-auto">
+        <!-- Header -->
+        <div class="bg-white rounded-lg shadow-md p-6 mb-6">
+            <h1 class="text-2xl font-bold text-gray-800">SSE Test Client</h1>
+            <p class="text-gray-600 mt-2">Listening for events from: <span class="font-mono text-sm bg-gray-100 px-2 py-1 rounded">http://localhost:8000/api/sse</span></p>
+            <div id="connection-status" class="mt-4">
+                <span class="inline-flex items-center">
+                    <span id="status-dot" class="h-3 w-3 bg-yellow-400 rounded-full mr-2"></span>
+                    <span id="status-text" class="text-sm text-gray-600">Connecting...</span>
+                </span>
+            </div>
+        </div>
+
+        <!-- Events Container -->
+        <div class="bg-white rounded-lg shadow-md p-6">
+            <div class="flex justify-between items-center mb-4">
+                <h2 class="text-lg font-semibold text-gray-800">Events</h2>
+                <button onclick="clearEvents()" class="px-3 py-1 text-sm text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded">
+                    Clear
+                </button>
+            </div>
+            <div id="events" class="space-y-2 max-h-[600px] overflow-y-auto"></div>
+        </div>
+    </div>
+
+    <script>
+        const eventsDiv = document.getElementById('events');
+        const statusDot = document.getElementById('status-dot');
+        const statusText = document.getElementById('status-text');
+        
+        function updateConnectionStatus(connected) {
+            statusDot.className = `h-3 w-3 rounded-full mr-2 ${connected ? 'bg-green-500' : 'bg-red-500'}`;
+            statusText.textContent = connected ? 'Connected' : 'Disconnected';
+            statusText.className = `text-sm ${connected ? 'text-green-600' : 'text-red-600'}`;
+        }
+
+        function clearEvents() {
+            eventsDiv.innerHTML = '';
+        }
+
+        // Connect to SSE endpoint
+        const eventSource = new EventSource('http://localhost:8000/api/sse');
+
+        // Listen for messages
+        eventSource.onmessage = function(event) {
+            try {
+                const data = JSON.parse(event.data);
+                const newEvent = document.createElement('div');
+                newEvent.className = 'p-3 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors';
+                
+                newEvent.innerHTML = `
+                    <div class="flex justify-between items-start">
+                        <div class="text-gray-800">${data.message}</div>
+                        <div class="text-xs text-gray-500 ml-4">${new Date(data.time).toLocaleTimeString()}</div>
+                    </div>
+                `;
+                
+                eventsDiv.prepend(newEvent);
+            } catch (e) {
+                console.error('Error parsing event data:', e);
+            }
+        };
+
+        // Handle connection open
+        eventSource.onopen = function() {
+            updateConnectionStatus(true);
+        };
+
+        // Handle errors
+        eventSource.onerror = function(error) {
+            console.error('SSE Error:', error);
+            updateConnectionStatus(false);
+            
+            const errorDiv = document.createElement('div');
+            errorDiv.className = 'p-3 bg-red-50 text-red-700 rounded-lg';
+            errorDiv.textContent = 'Connection error';
+            eventsDiv.prepend(errorDiv);
+        };
+    </script>
+</body>
+</html>

--- a/test/sseServer/sse_server.go
+++ b/test/sseServer/sse_server.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+)
+
+func sseHandler(w http.ResponseWriter, r *http.Request) {
+	// Set headers for SSE
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	// Create channel for client disconnect detection
+	notify := r.Context().Done()
+	go func() {
+		<-notify
+		log.Println("Client disconnected")
+	}()
+
+	// Send events every 2 seconds
+	for {
+		select {
+		case <-notify:
+			return
+		default:
+			// Create event data
+			event := fmt.Sprintf("data: {\"time\": \"%s\", \"message\": \"Test SSE Event\"}\n\n",
+				time.Now().Format(time.RFC3339))
+
+			// Write to response
+			_, err := fmt.Fprint(w, event)
+			if err != nil {
+				log.Printf("Error writing to stream: %v", err)
+				return
+			}
+
+			// Flush the response writer
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+
+			time.Sleep(2 * time.Second)
+		}
+	}
+}
+
+func main() {
+	http.HandleFunc("/sse", sseHandler)
+	log.Println("Starting SSE test server on :3000/sse")
+	if err := http.ListenAndServe(":3000", nil); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
# SSE Support and Test Environment

### Tradeoffs
- SSE routes dont has support to mapping feature

## Description
Added Server-Sent Events (SSE) support to the API Gateway with a test environment for developers.

## Features
- Added `isSSE` flag in route configuration to identify SSE endpoints
- Created SSE test server for development and testing
- Added SSE test client with modern UI for easy testing
- Added make command to run the test server

## Changes
- Added `isSSE` field to Route struct with `omitempty` tag
- Updated router to handle SSE routes without mapping
- Created test environment in `/test/sseServer` directory
- Added `sse-server` command to Makefile

## Test Environment
The test environment consists of:
- SSE test server (`test/sseServer/sse_server.go`)
- SSE test client (`test/sseServer/sse_client.html`)
- Example configuration in `config.yaml`

### How to Test
1. Start the SSE test server:
```bash
pnpm make sse-server
```
2. Open `test/sseServer/sse_client.html` in your browser
3. You should see events coming in every 2 seconds

## Configuration Example
```yaml
routes:
  - method: GET
    route: /sse
    service: localhost:3000
    path: /sse
    isSSE: true
```

## Screenshots

https://github.com/user-attachments/assets/187f69ce-68da-45c5-8573-68f658e2b6bf
