### PR TITLE
fix(auth): replace deprecated strings.Title and handle json.Encode error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/gorilla/mux v1.8.1
 	github.com/spf13/viper v1.19.0
+	golang.org/x/text v0.14.0
 )
 
 require (
@@ -25,7 +26,6 @@ require (
 	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/sys v0.18.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -26,7 +28,9 @@ type ErrorResponse struct {
 func jsonError(w http.ResponseWriter, message string, code int) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(code)
-	json.NewEncoder(w).Encode(ErrorResponse{Error: message, Success: false})
+	if err := json.NewEncoder(w).Encode(ErrorResponse{Error: message, Success: false}); err != nil {
+		log.Printf("Failed to encode JSON error response: %v", err)
+	}
 	log.Println("Invalid JWT token", message)
 }
 
@@ -73,9 +77,10 @@ func ValidateJWT(secret string, next http.Handler) http.Handler {
 				}
 			}
 
+			caser := cases.Title(language.Und)
 			for key, value := range claims {
 				if str, ok := value.(string); ok {
-					headerKey := fmt.Sprintf("%s%s", HeaderPrefix, strings.Title(key))
+					headerKey := HeaderPrefix + caser.String(key)
 					r.Header.Set(headerKey, str)
 				}
 			}


### PR DESCRIPTION
## Summary
- Replace `strings.Title` (deprecated since Go 1.18) with `golang.org/x/text/cases` for proper Unicode handling when building JWT claim headers
- Check error return value from `json.NewEncoder.Encode` in `jsonError` to prevent silently swallowing encoding failures
- Promote `golang.org/x/text` from indirect to direct dependency

Closes #9, Closes #10

## Test plan
- [x] Existing JWT tests pass (`go test ./internal/auth/...`)
- [x] `go vet ./...` clean
- [x] No behavior change — same header output, just uses non-deprecated API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in JWT authentication to properly log encoding failures.
  * Enhanced JWT claim header generation for better reliability.

* **Chores**
  * Updated dependencies to latest versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->