### PR TITLE
feat(test): add unit tests and e2e test suite with Docker

### DIFF
--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.23-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o tainha ./cmd/gateway
+
+FROM alpine:3.19
+COPY --from=builder /app/tainha /usr/local/bin/tainha
+ENTRYPOINT ["tainha"]

--- a/e2e/Dockerfile.test
+++ b/e2e/Dockerfile.test
@@ -1,0 +1,6 @@
+FROM golang:1.23-alpine
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY e2e_test.go .
+CMD ["go", "test", "-v", "-count=1", "./..."]

--- a/e2e/config.yaml
+++ b/e2e/config.yaml
@@ -1,0 +1,64 @@
+config:
+  port: 8080
+  basePath: /api
+  auth:
+    secret: "e2e-test-secret"
+    defaultProtected: true
+
+routes:
+  # Public: list all products with category mapping
+  - method: GET
+    route: /products
+    service: mock-service:4000
+    path: /products
+    public: true
+    mapping:
+      - path: /categories?id={categoryId}
+        service: mock-service:4000
+        tag: category
+        removeKeyMapping: true
+
+  # Public: get single product
+  - method: GET
+    route: /products/{productId}
+    service: mock-service:4000
+    path: /products/{productId}
+    public: true
+
+  # Protected: list all users
+  - method: GET
+    route: /users
+    service: mock-service:4000
+    path: /users
+
+  # Protected: get single user with orders mapping
+  - method: GET
+    route: /users/{userId}
+    service: mock-service:4000
+    path: /users/{userId}
+    mapping:
+      - path: /orders?userId={id}
+        service: mock-service:4000
+        tag: orders
+        removeKeyMapping: false
+
+  # Protected: list all orders
+  - method: GET
+    route: /orders
+    service: mock-service:4000
+    path: /orders
+
+  # Public: categories
+  - method: GET
+    route: /categories
+    service: mock-service:4000
+    path: /categories
+    public: true
+
+  # SSE: real-time stock events
+  - method: GET
+    route: /events
+    service: mock-service:4000
+    path: /events
+    isSSE: true
+    public: true

--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  mock-service:
+    build:
+      context: ./services
+      dockerfile: Dockerfile
+    environment:
+      - PORT=4000
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4000/products"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  gateway:
+    build:
+      context: ..
+      dockerfile: e2e/Dockerfile
+    working_dir: /app
+    volumes:
+      - ./config.yaml:/app/config/config.yaml:ro
+    depends_on:
+      mock-service:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/api/products"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+
+  test-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+    environment:
+      - E2E=true
+      - GATEWAY_URL=http://gateway:8080
+      - MOCK_URL=http://mock-service:4000
+    depends_on:
+      gateway:
+        condition: service_healthy

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -1,0 +1,446 @@
+package e2e
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+var (
+	gatewayURL = envOrDefault("GATEWAY_URL", "http://localhost:8080")
+	mockURL    = envOrDefault("MOCK_URL", "http://localhost:4000")
+)
+
+const jwtSecret = "e2e-test-secret"
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func TestMain(m *testing.M) {
+	if os.Getenv("E2E") != "true" {
+		fmt.Println("Skipping e2e tests (set E2E=true to run)")
+		os.Exit(0)
+	}
+
+	// Wait for gateway to be ready
+	if err := waitForService(gatewayURL+"/api/products", 30*time.Second); err != nil {
+		fmt.Printf("Gateway not ready: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Reset mock request log before tests
+	http.Post(mockURL+"/_requests/reset", "", nil)
+
+	os.Exit(m.Run())
+}
+
+// --- Public routes ---
+
+func TestPublicRoutes(t *testing.T) {
+	t.Run("GET /api/products without auth returns 200", func(t *testing.T) {
+		resp, err := http.Get(gatewayURL + "/api/products")
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		var products []map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&products)
+
+		if len(products) != 3 {
+			t.Fatalf("Expected 3 products, got %d", len(products))
+		}
+	})
+
+	t.Run("GET /api/products/{id} without auth returns 200", func(t *testing.T) {
+		resp, err := http.Get(gatewayURL + "/api/products/1")
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		var product map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&product)
+
+		if product["name"] != "Laptop" {
+			t.Errorf("product name = %v, want Laptop", product["name"])
+		}
+	})
+
+	t.Run("GET /api/categories without auth returns 200", func(t *testing.T) {
+		resp, err := http.Get(gatewayURL + "/api/categories")
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+	})
+}
+
+// --- Auth protection ---
+
+func TestAuthProtection(t *testing.T) {
+	t.Run("GET /api/users without token returns 401", func(t *testing.T) {
+		resp, err := http.Get(gatewayURL + "/api/users")
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 401 {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+
+		var errResp map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&errResp)
+
+		if errResp["success"] != false {
+			t.Error("Expected success=false in error response")
+		}
+	})
+
+	t.Run("GET /api/orders without token returns 401", func(t *testing.T) {
+		resp, err := http.Get(gatewayURL + "/api/orders")
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 401 {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("GET /api/users with invalid token returns 401", func(t *testing.T) {
+		req, _ := http.NewRequest("GET", gatewayURL+"/api/users", nil)
+		req.Header.Set("Authorization", "Bearer invalid.token.value")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 401 {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("GET /api/users with wrong secret returns 401", func(t *testing.T) {
+		token := generateToken("wrong-secret", map[string]interface{}{
+			"username": "hacker",
+		})
+
+		req, _ := http.NewRequest("GET", gatewayURL+"/api/users", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 401 {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+
+	t.Run("GET /api/users with valid token returns 200", func(t *testing.T) {
+		token := generateToken(jwtSecret, map[string]interface{}{
+			"username": "alice",
+			"role":     "admin",
+		})
+
+		req, _ := http.NewRequest("GET", gatewayURL+"/api/users", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		var users []map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&users)
+
+		if len(users) != 2 {
+			t.Errorf("Expected 2 users, got %d", len(users))
+		}
+	})
+
+	t.Run("GET /api/users with expired token returns 401", func(t *testing.T) {
+		token := generateToken(jwtSecret, map[string]interface{}{
+			"username": "alice",
+			"exp":      time.Now().Add(-1 * time.Hour).Unix(),
+		})
+
+		req, _ := http.NewRequest("GET", gatewayURL+"/api/users", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 401 {
+			t.Fatalf("status = %d, want 401", resp.StatusCode)
+		}
+	})
+}
+
+// --- JWT claim forwarding ---
+
+func TestClaimForwarding(t *testing.T) {
+	t.Run("JWT claims forwarded as X- headers to backend", func(t *testing.T) {
+		// Reset request log
+		http.Post(mockURL+"/_requests/reset", "", nil)
+
+		token := generateToken(jwtSecret, map[string]interface{}{
+			"username": "alice",
+			"role":     "admin",
+		})
+
+		req, _ := http.NewRequest("GET", gatewayURL+"/api/users", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		// Check the mock service's request log to verify headers were forwarded
+		logResp, err := http.Get(mockURL + "/_requests")
+		if err != nil {
+			t.Fatalf("Failed to get request log: %v", err)
+		}
+		defer logResp.Body.Close()
+
+		var requests []struct {
+			Method  string            `json:"method"`
+			Path    string            `json:"path"`
+			Headers map[string]string `json:"headers"`
+		}
+		json.NewDecoder(logResp.Body).Decode(&requests)
+
+		// Find the /users request
+		found := false
+		for _, r := range requests {
+			if r.Path == "/users" {
+				found = true
+				if r.Headers["X-Username"] != "alice" {
+					t.Errorf("X-Username = %q, want alice", r.Headers["X-Username"])
+				}
+				if r.Headers["X-Role"] != "admin" {
+					t.Errorf("X-Role = %q, want admin", r.Headers["X-Role"])
+				}
+				break
+			}
+		}
+		if !found {
+			t.Error("No /users request found in mock service log")
+		}
+	})
+}
+
+// --- Response mapping ---
+
+func TestResponseMapping(t *testing.T) {
+	t.Run("products have category mapping", func(t *testing.T) {
+		resp, err := http.Get(gatewayURL + "/api/products")
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		var products []map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&products)
+
+		for _, product := range products {
+			// categoryId should be removed (removeKeyMapping: true)
+			if _, ok := product["categoryId"]; ok {
+				t.Errorf("Product %v still has categoryId (should be removed by mapping)", product["id"])
+			}
+
+			// category should be present
+			cat, ok := product["category"]
+			if !ok {
+				t.Errorf("Product %v missing 'category' mapping", product["id"])
+				continue
+			}
+
+			catMap, ok := cat.(map[string]interface{})
+			if !ok {
+				t.Errorf("Product %v category is not an object: %T", product["id"], cat)
+				continue
+			}
+
+			if catMap["name"] == nil || catMap["name"] == "" {
+				t.Errorf("Product %v category has no name", product["id"])
+			}
+		}
+	})
+
+	t.Run("user has orders mapping", func(t *testing.T) {
+		token := generateToken(jwtSecret, map[string]interface{}{
+			"username": "alice",
+			"role":     "admin",
+		})
+
+		req, _ := http.NewRequest("GET", gatewayURL+"/api/users/1", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		var user map[string]interface{}
+		json.NewDecoder(resp.Body).Decode(&user)
+
+		orders, ok := user["orders"]
+		if !ok {
+			t.Fatal("User response missing 'orders' mapping")
+		}
+
+		orderList, ok := orders.([]interface{})
+		if !ok {
+			t.Fatalf("Orders is not an array: %T", orders)
+		}
+
+		if len(orderList) != 2 {
+			t.Errorf("Expected 2 orders for user 1, got %d", len(orderList))
+		}
+
+		// id should still be present (removeKeyMapping: false)
+		if _, ok := user["id"]; !ok {
+			t.Error("User 'id' should remain when removeKeyMapping is false")
+		}
+	})
+}
+
+// --- SSE ---
+
+func TestSSE(t *testing.T) {
+	t.Run("SSE endpoint streams events", func(t *testing.T) {
+		resp, err := http.Get(gatewayURL + "/api/events")
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 200 {
+			t.Fatalf("status = %d, want 200", resp.StatusCode)
+		}
+
+		scanner := bufio.NewScanner(resp.Body)
+		eventCount := 0
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.HasPrefix(line, "data: ") {
+				eventCount++
+				var event map[string]interface{}
+				if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &event); err != nil {
+					t.Errorf("Failed to parse SSE event: %v", err)
+				}
+				if event["message"] != "stock update" {
+					t.Errorf("event message = %v, want 'stock update'", event["message"])
+				}
+			}
+		}
+
+		if eventCount < 1 {
+			t.Errorf("Expected at least 1 SSE event, got %d", eventCount)
+		}
+	})
+}
+
+// --- Backend not found ---
+
+func TestBackendErrors(t *testing.T) {
+	t.Run("non-existent product returns 404", func(t *testing.T) {
+		resp, err := http.Get(gatewayURL + "/api/products/999")
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 404 {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 404, body = %s", resp.StatusCode, body)
+		}
+	})
+
+	t.Run("non-existent gateway route returns 405 or 404", func(t *testing.T) {
+		resp, err := http.Get(gatewayURL + "/api/nonexistent")
+		if err != nil {
+			t.Fatalf("Request failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != 404 && resp.StatusCode != 405 {
+			t.Fatalf("status = %d, want 404 or 405", resp.StatusCode)
+		}
+	})
+}
+
+// --- Helpers ---
+
+func generateToken(secret string, claims map[string]interface{}) string {
+	if _, ok := claims["exp"]; !ok {
+		claims["exp"] = time.Now().Add(time.Hour).Unix()
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
+	tokenString, _ := token.SignedString([]byte(secret))
+	return tokenString
+}
+
+func waitForService(url string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(url)
+		if err == nil && resp.StatusCode == 200 {
+			resp.Body.Close()
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return fmt.Errorf("service at %s not ready after %v", url, timeout)
+}

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,0 +1,5 @@
+module github.com/aguiar-sh/tainha/e2e
+
+go 1.23.2
+
+require github.com/golang-jwt/jwt/v5 v5.2.1

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -1,0 +1,2 @@
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/e2e/services/Dockerfile
+++ b/e2e/services/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.23-alpine AS builder
+WORKDIR /app
+COPY main.go .
+RUN go build -o mock-service main.go
+
+FROM alpine:3.19
+COPY --from=builder /app/mock-service /usr/local/bin/mock-service
+ENTRYPOINT ["mock-service"]

--- a/e2e/services/main.go
+++ b/e2e/services/main.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+)
+
+// Mock services for e2e testing: inventory system with products, categories, and users.
+// Each service runs on a different port, configured via environment variables.
+
+// --- Data ---
+
+var (
+	products = []map[string]interface{}{
+		{"id": "1", "name": "Laptop", "price": 2500.00, "categoryId": "1", "stock": 15},
+		{"id": "2", "name": "Mouse", "price": 49.90, "categoryId": "2", "stock": 200},
+		{"id": "3", "name": "Monitor", "price": 1200.00, "categoryId": "1", "stock": 30},
+	}
+
+	categories = []map[string]interface{}{
+		{"id": "1", "name": "Electronics", "description": "Electronic devices"},
+		{"id": "2", "name": "Accessories", "description": "Computer accessories"},
+	}
+
+	users = []map[string]interface{}{
+		{"id": "1", "name": "Alice", "email": "alice@example.com", "role": "admin"},
+		{"id": "2", "name": "Bob", "email": "bob@example.com", "role": "viewer"},
+	}
+
+	orders = []map[string]interface{}{
+		{"id": "1", "productId": "1", "userId": "1", "quantity": 2, "status": "shipped"},
+		{"id": "2", "productId": "2", "userId": "1", "quantity": 5, "status": "pending"},
+		{"id": "3", "productId": "3", "userId": "2", "quantity": 1, "status": "delivered"},
+	}
+
+	mu               sync.RWMutex
+	receivedHeaders  = make(map[string]map[string]string) // track headers per request path
+	requestLog       []RequestLogEntry
+	requestLogMu     sync.Mutex
+)
+
+type RequestLogEntry struct {
+	Method  string            `json:"method"`
+	Path    string            `json:"path"`
+	Headers map[string]string `json:"headers"`
+}
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "4000"
+	}
+
+	mux := http.NewServeMux()
+
+	// Products
+	mux.HandleFunc("/products", func(w http.ResponseWriter, r *http.Request) {
+		logRequest(r)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(products)
+	})
+	mux.HandleFunc("/products/", func(w http.ResponseWriter, r *http.Request) {
+		logRequest(r)
+		id := strings.TrimPrefix(r.URL.Path, "/products/")
+		for _, p := range products {
+			if p["id"] == id {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(p)
+				return
+			}
+		}
+		http.Error(w, `{"error":"product not found"}`, http.StatusNotFound)
+	})
+
+	// Categories
+	mux.HandleFunc("/categories", func(w http.ResponseWriter, r *http.Request) {
+		logRequest(r)
+		w.Header().Set("Content-Type", "application/json")
+		id := r.URL.Query().Get("id")
+		if id != "" {
+			for _, c := range categories {
+				if c["id"] == id {
+					json.NewEncoder(w).Encode(c)
+					return
+				}
+			}
+			http.Error(w, `{"error":"category not found"}`, http.StatusNotFound)
+			return
+		}
+		json.NewEncoder(w).Encode(categories)
+	})
+	mux.HandleFunc("/categories/", func(w http.ResponseWriter, r *http.Request) {
+		logRequest(r)
+		id := strings.TrimPrefix(r.URL.Path, "/categories/")
+		for _, c := range categories {
+			if c["id"] == id {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(c)
+				return
+			}
+		}
+		http.Error(w, `{"error":"category not found"}`, http.StatusNotFound)
+	})
+
+	// Users
+	mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
+		logRequest(r)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(users)
+	})
+	mux.HandleFunc("/users/", func(w http.ResponseWriter, r *http.Request) {
+		logRequest(r)
+		id := strings.TrimPrefix(r.URL.Path, "/users/")
+		for _, u := range users {
+			if u["id"] == id {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(u)
+				return
+			}
+		}
+		http.Error(w, `{"error":"user not found"}`, http.StatusNotFound)
+	})
+
+	// Orders
+	mux.HandleFunc("/orders", func(w http.ResponseWriter, r *http.Request) {
+		logRequest(r)
+		w.Header().Set("Content-Type", "application/json")
+		userId := r.URL.Query().Get("userId")
+		if userId != "" {
+			var filtered []map[string]interface{}
+			for _, o := range orders {
+				if o["userId"] == userId {
+					filtered = append(filtered, o)
+				}
+			}
+			json.NewEncoder(w).Encode(filtered)
+			return
+		}
+		json.NewEncoder(w).Encode(orders)
+	})
+
+	// SSE endpoint
+	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
+		logRequest(r)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming not supported", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+
+		for i := 0; i < 3; i++ {
+			fmt.Fprintf(w, "data: {\"event\":%d,\"message\":\"stock update\"}\n\n", i+1)
+			flusher.Flush()
+		}
+	})
+
+	// Introspection endpoints for e2e test assertions
+	mux.HandleFunc("/_requests", func(w http.ResponseWriter, r *http.Request) {
+		requestLogMu.Lock()
+		defer requestLogMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(requestLog)
+	})
+	mux.HandleFunc("/_requests/reset", func(w http.ResponseWriter, r *http.Request) {
+		requestLogMu.Lock()
+		defer requestLogMu.Unlock()
+		requestLog = nil
+		w.WriteHeader(http.StatusOK)
+	})
+
+	log.Printf("Mock service starting on :%s\n", port)
+	if err := http.ListenAndServe(":"+port, mux); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func logRequest(r *http.Request) {
+	headers := make(map[string]string)
+	for key := range r.Header {
+		if strings.HasPrefix(key, "X-") {
+			headers[key] = r.Header.Get(key)
+		}
+	}
+
+	mu.Lock()
+	receivedHeaders[r.URL.Path] = headers
+	mu.Unlock()
+
+	entry := RequestLogEntry{
+		Method:  r.Method,
+		Path:    r.URL.RequestURI(),
+		Headers: headers,
+	}
+	requestLogMu.Lock()
+	requestLog = append(requestLog, entry)
+	requestLogMu.Unlock()
+
+	log.Printf("[%s] %s headers=%v", r.Method, r.URL.RequestURI(), headers)
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	t.Run("valid config", func(t *testing.T) {
+		yaml := `
+config:
+  port: 9000
+  basePath: /api
+  auth:
+    secret: "test-secret"
+    defaultProtected: true
+
+routes:
+  - method: GET
+    route: /products
+    service: localhost:4000
+    path: /products
+    public: true
+  - method: GET
+    route: /users/{userId}
+    service: localhost:4000
+    path: /users/{userId}
+    mapping:
+      - path: /orders?userId={id}
+        service: localhost:4001
+        tag: orders
+        removeKeyMapping: false
+`
+		path := writeTempConfig(t, yaml)
+		cfg, err := LoadConfig(path)
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v", err)
+		}
+
+		if cfg.BaseConfig.Port != 9000 {
+			t.Errorf("Port = %d, want 9000", cfg.BaseConfig.Port)
+		}
+		if cfg.BaseConfig.BasePath != "/api" {
+			t.Errorf("BasePath = %q, want /api", cfg.BaseConfig.BasePath)
+		}
+		if cfg.BaseConfig.Auth.Secret != "test-secret" {
+			t.Errorf("Auth.Secret = %q, want test-secret", cfg.BaseConfig.Auth.Secret)
+		}
+		if !cfg.BaseConfig.Auth.DefaultProtected {
+			t.Error("Auth.DefaultProtected = false, want true")
+		}
+		if len(cfg.Routes) != 2 {
+			t.Fatalf("len(Routes) = %d, want 2", len(cfg.Routes))
+		}
+
+		route := cfg.Routes[0]
+		if route.Method != "GET" || route.Route != "/products" || route.Service != "localhost:4000" {
+			t.Errorf("Route[0] = %+v, unexpected values", route)
+		}
+		if !route.Public {
+			t.Error("Route[0].Public = false, want true")
+		}
+
+		route = cfg.Routes[1]
+		if len(route.Mapping) != 1 {
+			t.Fatalf("Route[1].Mapping len = %d, want 1", len(route.Mapping))
+		}
+		if route.Mapping[0].Tag != "orders" {
+			t.Errorf("Route[1].Mapping[0].Tag = %q, want orders", route.Mapping[0].Tag)
+		}
+	})
+
+	t.Run("sse route", func(t *testing.T) {
+		yaml := `
+config:
+  port: 8000
+  basePath: /api
+  auth:
+    secret: "secret"
+    defaultProtected: false
+
+routes:
+  - method: GET
+    route: /events
+    service: localhost:3001
+    path: /sse
+    isSSE: true
+    public: true
+`
+		path := writeTempConfig(t, yaml)
+		cfg, err := LoadConfig(path)
+		if err != nil {
+			t.Fatalf("LoadConfig() error = %v", err)
+		}
+
+		if !cfg.Routes[0].IsSSE {
+			t.Error("Route.IsSSE = false, want true")
+		}
+	})
+
+	t.Run("file not found", func(t *testing.T) {
+		_, err := LoadConfig("/nonexistent/config.yaml")
+		if err == nil {
+			t.Error("LoadConfig() expected error for missing file")
+		}
+	})
+
+	t.Run("invalid yaml", func(t *testing.T) {
+		path := writeTempConfig(t, `{{{invalid`)
+		_, err := LoadConfig(path)
+		if err == nil {
+			t.Error("LoadConfig() expected error for invalid yaml")
+		}
+	})
+}
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/mapper/mapper_test.go
+++ b/internal/mapper/mapper_test.go
@@ -1,0 +1,220 @@
+package mapper
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aguiar-sh/tainha/internal/config"
+)
+
+func TestMap(t *testing.T) {
+	t.Run("array response with mapping", func(t *testing.T) {
+		// Mock backend that returns comments for a postId
+		mockService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			postId := r.URL.Query().Get("postId")
+			comments := []map[string]interface{}{
+				{"id": "1", "text": "comment for post " + postId, "postId": postId},
+			}
+			json.NewEncoder(w).Encode(comments)
+		}))
+		defer mockService.Close()
+
+		route := config.Route{
+			Mapping: []config.RouteMapping{
+				{
+					Path:             "/comments?postId={id}",
+					Service:          mockService.URL,
+					Tag:              "comments",
+					RemoveKeyMapping: false,
+				},
+			},
+		}
+
+		input := `[{"id":"1","title":"Post 1"},{"id":"2","title":"Post 2"}]`
+		result, err := Map(route, []byte(input))
+		if err != nil {
+			t.Fatalf("Map() error = %v", err)
+		}
+
+		var parsed []map[string]interface{}
+		if err := json.Unmarshal(result, &parsed); err != nil {
+			t.Fatalf("Failed to parse result: %v", err)
+		}
+
+		if len(parsed) != 2 {
+			t.Fatalf("Expected 2 items, got %d", len(parsed))
+		}
+
+		for _, item := range parsed {
+			if _, ok := item["comments"]; !ok {
+				t.Errorf("Expected 'comments' key in mapped response, got: %v", item)
+			}
+			// id should still be present since removeKeyMapping is false
+			if _, ok := item["id"]; !ok {
+				t.Error("Expected 'id' key to remain when removeKeyMapping is false")
+			}
+		}
+	})
+
+	t.Run("array response with removeKeyMapping", func(t *testing.T) {
+		mockService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]string{"name": "Mapped Data"})
+		}))
+		defer mockService.Close()
+
+		route := config.Route{
+			Mapping: []config.RouteMapping{
+				{
+					Path:             "/details/{categoryId}",
+					Service:          mockService.URL,
+					Tag:              "category",
+					RemoveKeyMapping: true,
+				},
+			},
+		}
+
+		input := `[{"id":"1","categoryId":"cat-1"}]`
+		result, err := Map(route, []byte(input))
+		if err != nil {
+			t.Fatalf("Map() error = %v", err)
+		}
+
+		var parsed []map[string]interface{}
+		json.Unmarshal(result, &parsed)
+
+		if _, ok := parsed[0]["categoryId"]; ok {
+			t.Error("Expected 'categoryId' to be removed when removeKeyMapping is true")
+		}
+		if _, ok := parsed[0]["category"]; !ok {
+			t.Error("Expected 'category' tag to be present in mapped response")
+		}
+	})
+
+	t.Run("single object response", func(t *testing.T) {
+		mockService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]string{"name": "Company A"})
+		}))
+		defer mockService.Close()
+
+		route := config.Route{
+			Mapping: []config.RouteMapping{
+				{
+					Path:             "/companies?id={companyId}",
+					Service:          mockService.URL,
+					Tag:              "company",
+					RemoveKeyMapping: true,
+				},
+			},
+		}
+
+		input := `{"id":"1","name":"John","companyId":"10"}`
+		result, err := Map(route, []byte(input))
+		if err != nil {
+			t.Fatalf("Map() error = %v", err)
+		}
+
+		var parsed map[string]interface{}
+		json.Unmarshal(result, &parsed)
+
+		if _, ok := parsed["company"]; !ok {
+			t.Error("Expected 'company' tag in single object response")
+		}
+		if _, ok := parsed["companyId"]; ok {
+			t.Error("Expected 'companyId' to be removed")
+		}
+	})
+
+	t.Run("no mappings", func(t *testing.T) {
+		route := config.Route{Mapping: nil}
+		input := `[{"id":"1","name":"test"}]`
+
+		result, err := Map(route, []byte(input))
+		if err != nil {
+			t.Fatalf("Map() error = %v", err)
+		}
+
+		var parsed []map[string]interface{}
+		json.Unmarshal(result, &parsed)
+
+		if len(parsed) != 1 || parsed[0]["name"] != "test" {
+			t.Errorf("Expected unchanged data, got %s", result)
+		}
+	})
+
+	t.Run("invalid json input", func(t *testing.T) {
+		route := config.Route{}
+		_, err := Map(route, []byte("not json"))
+		if err == nil {
+			t.Error("Expected error for invalid JSON input")
+		}
+	})
+
+	t.Run("mapping service unavailable", func(t *testing.T) {
+		route := config.Route{
+			Mapping: []config.RouteMapping{
+				{
+					Path:    "/data/{id}",
+					Service: "http://localhost:1", // unreachable
+					Tag:     "data",
+				},
+			},
+		}
+
+		input := `[{"id":"1","name":"test"}]`
+		result, err := Map(route, []byte(input))
+		if err != nil {
+			t.Fatalf("Map() should not return error for failed mappings, got: %v", err)
+		}
+
+		var parsed []map[string]interface{}
+		json.Unmarshal(result, &parsed)
+
+		// Data tag should not be present since the request failed
+		if _, ok := parsed[0]["data"]; ok {
+			t.Error("Expected 'data' tag to be absent when mapping service is unavailable")
+		}
+	})
+
+	t.Run("multiple mappings on same item", func(t *testing.T) {
+		callCount := 0
+		mockService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			json.NewEncoder(w).Encode(map[string]string{"result": fmt.Sprintf("mapped-%d", callCount)})
+		}))
+		defer mockService.Close()
+
+		route := config.Route{
+			Mapping: []config.RouteMapping{
+				{
+					Path:    "/users/{authorId}",
+					Service: mockService.URL,
+					Tag:     "author",
+				},
+				{
+					Path:    "/categories/{categoryId}",
+					Service: mockService.URL,
+					Tag:     "category",
+				},
+			},
+		}
+
+		input := `[{"id":"1","authorId":"a1","categoryId":"c1"}]`
+		result, err := Map(route, []byte(input))
+		if err != nil {
+			t.Fatalf("Map() error = %v", err)
+		}
+
+		var parsed []map[string]interface{}
+		json.Unmarshal(result, &parsed)
+
+		if _, ok := parsed[0]["author"]; !ok {
+			t.Error("Expected 'author' tag")
+		}
+		if _, ok := parsed[0]["category"]; !ok {
+			t.Error("Expected 'category' tag")
+		}
+	})
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,47 @@
+package proxy
+
+import (
+	"testing"
+)
+
+func TestNewReverseProxy(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  string
+		wantErr bool
+	}{
+		{
+			name:    "valid http target",
+			target:  "http://localhost:3000",
+			wantErr: false,
+		},
+		{
+			name:    "valid https target",
+			target:  "https://api.example.com",
+			wantErr: false,
+		},
+		{
+			name:    "valid target with path",
+			target:  "http://localhost:3000/api/v1",
+			wantErr: false,
+		},
+		{
+			name:    "invalid target",
+			target:  "://invalid",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy, err := NewReverseProxy(tt.target)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewReverseProxy(%q) error = %v, wantErr %v", tt.target, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && proxy == nil {
+				t.Errorf("NewReverseProxy(%q) returned nil proxy without error", tt.target)
+			}
+		})
+	}
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1,0 +1,307 @@
+package router
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aguiar-sh/tainha/internal/config"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestCORSMiddleware(t *testing.T) {
+	cfg := &config.Config{
+		BaseConfig: config.BaseConfig{
+			BasePath: "/api",
+			Auth:     config.AuthConfig{Secret: "secret", DefaultProtected: false},
+		},
+		Routes: []config.Route{
+			{Method: "GET", Route: "/test", Service: "localhost:9999", Path: "/test", Public: true},
+		},
+	}
+
+	backend := startMockBackend(t, `{"ok":true}`)
+	cfg.Routes[0].Service = stripScheme(backend.URL)
+
+	r, err := SetupRouter(cfg)
+	if err != nil {
+		t.Fatalf("SetupRouter() error = %v", err)
+	}
+
+	t.Run("CORS headers present", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/test", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if got := rr.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Errorf("Access-Control-Allow-Origin = %q, want *", got)
+		}
+		if got := rr.Header().Get("Access-Control-Allow-Methods"); got == "" {
+			t.Error("Access-Control-Allow-Methods header missing")
+		}
+	})
+
+	t.Run("OPTIONS preflight returns 200", func(t *testing.T) {
+		req := httptest.NewRequest("OPTIONS", "/api/test", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("OPTIONS status = %d, want 200", rr.Code)
+		}
+	})
+}
+
+func TestRouterProxying(t *testing.T) {
+	t.Run("basic proxy to backend", func(t *testing.T) {
+		backend := startMockBackend(t, `{"message":"hello"}`)
+
+		cfg := &config.Config{
+			BaseConfig: config.BaseConfig{
+				BasePath: "/api",
+				Auth:     config.AuthConfig{DefaultProtected: false},
+			},
+			Routes: []config.Route{
+				{Method: "GET", Route: "/hello", Service: stripScheme(backend.URL), Path: "/hello", Public: true},
+			},
+		}
+
+		r, _ := SetupRouter(cfg)
+		req := httptest.NewRequest("GET", "/api/hello", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rr.Code)
+		}
+
+		var body map[string]interface{}
+		json.Unmarshal(rr.Body.Bytes(), &body)
+		if body["message"] != "hello" {
+			t.Errorf("body = %v, want message=hello", body)
+		}
+	})
+
+	t.Run("path params forwarded", func(t *testing.T) {
+		var receivedPath string
+		backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedPath = r.URL.Path
+			json.NewEncoder(w).Encode(map[string]string{"id": "42"})
+		}))
+		t.Cleanup(backend.Close)
+
+		cfg := &config.Config{
+			BaseConfig: config.BaseConfig{
+				BasePath: "/api",
+				Auth:     config.AuthConfig{DefaultProtected: false},
+			},
+			Routes: []config.Route{
+				{Method: "GET", Route: "/users/{userId}", Service: stripScheme(backend.URL), Path: "/users/{userId}", Public: true},
+			},
+		}
+
+		r, _ := SetupRouter(cfg)
+		req := httptest.NewRequest("GET", "/api/users/42", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rr.Code)
+		}
+		if receivedPath != "/users/42" {
+			t.Errorf("backend received path = %q, want /users/42", receivedPath)
+		}
+	})
+
+	t.Run("backend error forwarded", func(t *testing.T) {
+		backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			w.Write([]byte(`{"error":"not found"}`))
+		}))
+		t.Cleanup(backend.Close)
+
+		cfg := &config.Config{
+			BaseConfig: config.BaseConfig{
+				BasePath: "/api",
+				Auth:     config.AuthConfig{DefaultProtected: false},
+			},
+			Routes: []config.Route{
+				{Method: "GET", Route: "/missing", Service: stripScheme(backend.URL), Path: "/missing", Public: true},
+			},
+		}
+
+		r, _ := SetupRouter(cfg)
+		req := httptest.NewRequest("GET", "/api/missing", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want 404", rr.Code)
+		}
+	})
+}
+
+func TestRouterWithAuth(t *testing.T) {
+	const secret = "test-secret-key"
+
+	backend := startMockBackend(t, `{"data":"protected"}`)
+
+	cfg := &config.Config{
+		BaseConfig: config.BaseConfig{
+			BasePath: "/api",
+			Auth:     config.AuthConfig{Secret: secret, DefaultProtected: true},
+		},
+		Routes: []config.Route{
+			{Method: "GET", Route: "/protected", Service: stripScheme(backend.URL), Path: "/protected"},
+			{Method: "GET", Route: "/public", Service: stripScheme(backend.URL), Path: "/public", Public: true},
+		},
+	}
+
+	r, _ := SetupRouter(cfg)
+
+	t.Run("protected route without token returns 401", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/protected", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", rr.Code)
+		}
+	})
+
+	t.Run("protected route with valid token returns 200", func(t *testing.T) {
+		token := generateTestToken(secret, map[string]interface{}{
+			"username": "testuser",
+			"role":     "admin",
+		})
+
+		req := httptest.NewRequest("GET", "/api/protected", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rr.Code)
+		}
+	})
+
+	t.Run("protected route with invalid token returns 401", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/protected", nil)
+		req.Header.Set("Authorization", "Bearer invalid.token.here")
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401", rr.Code)
+		}
+	})
+
+	t.Run("public route without token returns 200", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/public", nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rr.Code)
+		}
+	})
+}
+
+func TestRouterWithMapping(t *testing.T) {
+	// Backend that serves both products and categories
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/products":
+			json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"id": "1", "name": "Product A", "categoryId": "c1"},
+			})
+		case r.URL.Path == "/categories":
+			catId := r.URL.Query().Get("id")
+			json.NewEncoder(w).Encode(map[string]string{"id": catId, "name": "Electronics"})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	t.Cleanup(backend.Close)
+
+	host := stripScheme(backend.URL)
+	cfg := &config.Config{
+		BaseConfig: config.BaseConfig{
+			BasePath: "/api",
+			Auth:     config.AuthConfig{DefaultProtected: false},
+		},
+		Routes: []config.Route{
+			{
+				Method:  "GET",
+				Route:   "/products",
+				Service: host,
+				Path:    "/products",
+				Public:  true,
+				Mapping: []config.RouteMapping{
+					{
+						Path:             "/categories?id={categoryId}",
+						Service:          backend.URL,
+						Tag:              "category",
+						RemoveKeyMapping: true,
+					},
+				},
+			},
+		},
+	}
+
+	r, _ := SetupRouter(cfg)
+	req := httptest.NewRequest("GET", "/api/products", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+
+	var result []map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse response: %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Fatalf("Expected 1 product, got %d", len(result))
+	}
+
+	if _, ok := result[0]["category"]; !ok {
+		t.Error("Expected 'category' mapping in response")
+	}
+	if _, ok := result[0]["categoryId"]; ok {
+		t.Error("Expected 'categoryId' to be removed (removeKeyMapping: true)")
+	}
+}
+
+// helpers
+
+func startMockBackend(t *testing.T, responseBody string) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(responseBody))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func stripScheme(url string) string {
+	// Remove http:// prefix for the config (PathProtocol will add it back)
+	if len(url) > 7 && url[:7] == "http://" {
+		return url[7:]
+	}
+	return url
+}
+
+func generateTestToken(secret string, claims map[string]interface{}) string {
+	if claims["exp"] == nil {
+		claims["exp"] = time.Now().Add(time.Hour).Unix()
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(claims))
+	tokenString, _ := token.SignedString([]byte(secret))
+	return tokenString
+}

--- a/internal/util/extractPathParams_test.go
+++ b/internal/util/extractPathParams_test.go
@@ -1,0 +1,54 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestExtractPathParams(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want []string
+	}{
+		{
+			name: "no params",
+			path: "/posts",
+			want: []string{},
+		},
+		{
+			name: "single param",
+			path: "/users/{userId}",
+			want: []string{"userId"},
+		},
+		{
+			name: "multiple params",
+			path: "/companies/{companyId}/users/{userId}",
+			want: []string{"companyId", "userId"},
+		},
+		{
+			name: "query string param",
+			path: "/comments?postId={id}",
+			want: []string{"id"},
+		},
+		{
+			name: "empty path",
+			path: "",
+			want: []string{},
+		},
+		{
+			name: "param at root",
+			path: "/{id}",
+			want: []string{"id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractPathParams(tt.path)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ExtractPathParams(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/util/pathProtocol_test.go
+++ b/internal/util/pathProtocol_test.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestPathProtocol(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantPath     string
+		wantProtocol string
+	}{
+		{
+			name:         "plain host",
+			input:        "localhost:3000",
+			wantPath:     "localhost:3000",
+			wantProtocol: "http",
+		},
+		{
+			name:         "http prefix",
+			input:        "http://localhost:3000",
+			wantPath:     "localhost:3000",
+			wantProtocol: "http",
+		},
+		{
+			name:         "https prefix",
+			input:        "https://api.example.com",
+			wantPath:     "api.example.com",
+			wantProtocol: "https",
+		},
+		{
+			name:         "http with path",
+			input:        "http://localhost:3000/api",
+			wantPath:     "localhost:3000/api",
+			wantProtocol: "http",
+		},
+		{
+			name:         "plain domain",
+			input:        "api.example.com",
+			wantPath:     "api.example.com",
+			wantProtocol: "http",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotProtocol := PathProtocol(tt.input)
+			if gotPath != tt.wantPath {
+				t.Errorf("PathProtocol(%q) path = %q, want %q", tt.input, gotPath, tt.wantPath)
+			}
+			if gotProtocol != tt.wantProtocol {
+				t.Errorf("PathProtocol(%q) protocol = %q, want %q", tt.input, gotProtocol, tt.wantProtocol)
+			}
+		})
+	}
+}

--- a/makefile
+++ b/makefile
@@ -9,4 +9,18 @@ sse-server:
 run-sse:
 	@go run test/sseServer/sse_server.go -port=${PORT}
 
-.PHONY: run run-sse
+# Unit tests
+test:
+	go test ./internal/... -v
+
+# E2E tests (requires Docker)
+e2e:
+	docker compose -f e2e/docker-compose.yml up --build --abort-on-container-exit --exit-code-from test-runner
+
+e2e-down:
+	docker compose -f e2e/docker-compose.yml down -v
+
+e2e-logs:
+	docker compose -f e2e/docker-compose.yml logs -f
+
+.PHONY: run run-sse test e2e e2e-down e2e-logs


### PR DESCRIPTION
## Summary
- Add unit tests for all packages: config, proxy, util, mapper, and router (34 tests)
- Add Dockerized e2e test suite simulating an inventory system with auth, mapping, and SSE (15 tests)
- Add Makefile targets: `make test` (unit) and `make e2e` (Docker e2e)

## Unit tests coverage
| Package | Tests | Covers |
|---------|-------|--------|
| config | 4 | LoadConfig with valid/invalid YAML, SSE, missing files |
| proxy | 4 | HTTP/HTTPS targets, invalid URLs |
| util | 11 | ExtractPathParams, PathProtocol |
| mapper | 7 | Arrays, objects, removeKeyMapping, service down, concurrent mappings |
| router | 9 | CORS, proxying, path params, auth, response mapping |

## E2E scenario
Inventory system with mock services (products, categories, users, orders):
- Public vs protected route access
- JWT validation (missing, invalid, expired, wrong secret)
- JWT claim forwarding as X- headers (verified via mock introspection)
- Response mapping (product → category enrichment)
- SSE streaming passthrough
- Backend error propagation

## Test plan
- [x] `make test` — all 34 unit tests pass
- [x] `make e2e` — all 15 e2e tests pass in Docker