### PR TITLE
fix(mapper): race condition + rewrite README

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,4 +14,5 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.23'
-      - run: go test ./internal/... -v
+      - run: go vet ./...
+      - run: go test -race ./internal/... -v

--- a/README.md
+++ b/README.md
@@ -1,37 +1,185 @@
 ![Tainha logo](https://github.com/user-attachments/assets/a1286b71-5b0b-4d1e-90c6-177dd9ca5fe5)
 
-**Tainha** is an open-source API Gateway developed in Go (Golang), inspired by the rich culture of Florianópolis. Designed to be an affordable and efficient solution, Tainha simplifies routing HTTP requests to various backend services with ease and flexibility.
+# Tainha Gateway
 
-## 🌟 Features
+A lightweight, open-source API Gateway written in Go. Route requests, validate auth, aggregate responses from multiple services, and monitor everything — all from a single YAML config.
 
-- [x] **Simple Routing:** Direct requests to backend services based on defined routes.
-- [x] **Request with Parameters:** Handle routes with dynamic parameters like `{userId}`.
-- [x] **Request with Queries:** Support query parameters in routes and mappings.
-- [x] **Circular Requesting:** Allow chained API calls between services.
-- [ ] **Mapping Cache:** Implement caching for mapped responses to improve performance.
-- [ ] **Rate Limiting:** Control the rate of incoming requests to protect backend services.
-- [ ] **JWT Validation with JWK:** Authenticate requests using JSON Web Tokens and JSON Web Keys.
-- [x] **Open Source:** Contribute and customize Tainha to fit your needs.
+[![Tests](https://github.com/lusqua/tainha-gateway/actions/workflows/tests.yml/badge.svg)](https://github.com/lusqua/tainha-gateway/actions/workflows/tests.yml)
+[![Docs](https://github.com/lusqua/tainha-gateway/actions/workflows/docs.yml/badge.svg)](https://lusqua.github.io/tainha-gateway)
 
-We are on developing, feel free to collaborate
+**[Documentation](https://lusqua.github.io/tainha-gateway)** | **[Getting Started](https://lusqua.github.io/tainha-gateway/docs/getting-started)** | **[Configuration](https://lusqua.github.io/tainha-gateway/docs/configuration)**
 
-## 🚀 How to test
+## Features
 
-To test the application, you can use the *json-server* with `test/db.json` file.
+- **Routing** — dynamic path params, query strings, configurable base path
+- **Authentication** — local JWT validation (HS256) or delegate to your own auth service
+- **Response Mapping** — enrich responses by aggregating data from multiple services in parallel
+- **SSE** — Server-Sent Events passthrough for real-time streaming
+- **Rate Limiting** — token bucket per IP with X-Forwarded-For support
+- **Observability** — OpenTelemetry traces, Prometheus metrics (`/metrics`), structured JSON logs
+- **Health Check** — `GET /health` for load balancers and k8s probes
+- **Request Tracing** — `X-Request-ID` generated per request, propagated to backends
+- **Graceful Shutdown** — SIGTERM handling with connection draining
+- **Config Validation** — fail fast on startup with clear error messages
 
-
-```bash
-npx json-server --watch test/db.json --port 3000
-```
-
-Then, you can start the Tainha application with the following command:
+## Quick Start
 
 ```bash
-make run
+git clone https://github.com/lusqua/tainha-gateway.git
+cd tainha-gateway
 ```
 
-or
+Create `config/config.yaml`:
+
+```yaml
+config:
+  port: 8000
+  basePath: /api
+  auth:
+    secret: "your-secret"
+    defaultProtected: false
+
+routes:
+  - method: GET
+    route: /users
+    service: localhost:3000
+    path: /users
+    public: true
+```
+
+Run:
 
 ```bash
 go run cmd/gateway/main.go
 ```
+
+```bash
+curl http://localhost:8000/api/users
+```
+
+## Configuration
+
+```yaml
+config:
+  port: 8000
+  basePath: /api
+  readTimeoutSec: 15
+  writeTimeoutSec: 30
+  idleTimeoutSec: 60
+
+  auth:
+    secret: "your-secret"           # Local JWT (HS256)
+    defaultProtected: true
+    # Or delegate to your auth service:
+    # authService: localhost:5000
+    # authPath: /auth/validate
+
+  rateLimit:
+    enabled: true
+    requestsPerSec: 100
+    burst: 200
+
+  telemetry:
+    enabled: true
+    serviceName: tainha-gateway
+    exporterEndpoint: localhost:4317   # OTLP gRPC (Jaeger, Tempo)
+
+routes:
+  - method: GET
+    route: /products
+    service: localhost:3000
+    path: /products
+    public: true
+    mapping:
+      - path: /categories?id={categoryId}
+        service: localhost:3000
+        tag: category
+        removeKeyMapping: true
+```
+
+See the full [Configuration Reference](https://lusqua.github.io/tainha-gateway/docs/configuration).
+
+## Response Mapping
+
+Aggregate data from multiple services in a single response:
+
+```yaml
+routes:
+  - method: GET
+    route: /posts
+    service: localhost:3000
+    path: /posts
+    mapping:
+      - path: /comments?postId={id}
+        service: localhost:3000
+        tag: comments
+      - path: /users/{userId}
+        service: localhost:3000
+        tag: author
+        removeKeyMapping: true
+```
+
+The gateway fetches posts, then enriches each one with comments and author data in parallel.
+
+## Auth Delegation
+
+Bring your own auth service. The gateway forwards the `Authorization` header to your service — you validate with any strategy (RS256, OAuth2, API keys, etc.):
+
+```yaml
+config:
+  auth:
+    authService: localhost:5000
+    authPath: /auth/validate
+    defaultProtected: true
+```
+
+Your service returns `200` with claims → forwarded as `X-` headers. Non-200 → forwarded to client.
+
+See the [Auth Delegation docs](https://lusqua.github.io/tainha-gateway/docs/authentication/delegation) for the full contract and examples in Go and Node.js.
+
+## Observability
+
+With `telemetry.enabled: true`:
+
+- **`GET /metrics`** — Prometheus metrics (request count, latency, error rate, rate limit hits)
+- **OTLP Traces** — spans for each request with child spans for proxy and mapping calls
+- **Structured Logs** — JSON via `slog` with request IDs
+- **W3C Trace Context** — propagated to backends automatically
+
+## Testing
+
+```bash
+# Unit tests (102 test cases)
+make test
+
+# E2E tests with Docker (inventory system scenario)
+make e2e
+```
+
+## Roadmap
+
+- [x] Routing with path params and query strings
+- [x] JWT authentication (HS256)
+- [x] Auth delegation to external services
+- [x] Response mapping (parallel aggregation)
+- [x] Server-Sent Events
+- [x] Rate limiting
+- [x] OpenTelemetry traces + Prometheus metrics
+- [x] Graceful shutdown
+- [x] Health check
+- [x] Structured logging
+- [x] Config validation
+- [x] Request ID tracing
+- [ ] Mapping cache
+- [ ] Circuit breaker
+- [ ] WebSocket support
+- [ ] Hot config reload
+- [ ] JWT with RS256 / JWK
+
+## Contributing
+
+Contributions are welcome. Open an issue or submit a pull request.
+
+## License
+
+[MIT](LICENSE)

--- a/internal/mapper/mapper.go
+++ b/internal/mapper/mapper.go
@@ -45,15 +45,21 @@ func Map(route config.Route, response []byte) ([]byte, error) {
 	var wg sync.WaitGroup
 	errChan := make(chan error, len(dataToProcess)*len(route.Mapping))
 
+	// One mutex per item to avoid race conditions on concurrent map writes
+	itemMu := make([]sync.Mutex, len(dataToProcess))
+
 	for i := range dataToProcess {
 		for _, mapping := range route.Mapping {
 			wg.Add(1)
-			go func(item map[string]interface{}, mapping config.RouteMapping) {
+			go func(idx int, item map[string]interface{}, mapping config.RouteMapping) {
 				defer wg.Done()
 				pathParams := util.ExtractPathParams(mapping.Path)
 
 				for _, param := range pathParams {
+					itemMu[idx].Lock()
 					value, exists := item[param]
+					itemMu[idx].Unlock()
+
 					if !exists {
 						continue
 					}
@@ -86,13 +92,14 @@ func Map(route config.Route, response []byte) ([]byte, error) {
 						return
 					}
 
+					itemMu[idx].Lock()
 					item[mapping.Tag] = mappedData
-
 					if mapping.RemoveKeyMapping {
 						delete(item, param)
 					}
+					itemMu[idx].Unlock()
 				}
-			}(dataToProcess[i], mapping)
+			}(i, dataToProcess[i], mapping)
 		}
 	}
 

--- a/internal/mapper/mapper_test.go
+++ b/internal/mapper/mapper_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/aguiar-sh/tainha/internal/config"
@@ -179,10 +180,10 @@ func TestMap(t *testing.T) {
 	})
 
 	t.Run("multiple mappings on same item", func(t *testing.T) {
-		callCount := 0
+		var callCount atomic.Int32
 		mockService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			callCount++
-			json.NewEncoder(w).Encode(map[string]string{"result": fmt.Sprintf("mapped-%d", callCount)})
+			n := callCount.Add(1)
+			json.NewEncoder(w).Encode(map[string]string{"result": fmt.Sprintf("mapped-%d", n)})
 		}))
 		defer mockService.Close()
 


### PR DESCRIPTION
## Summary
- **Fix race condition** in mapper: concurrent goroutines were modifying the same map without synchronization. Added per-item mutex.
- **Fix test race**: atomic counter in mock server for `-race` compatibility.
- **CI hardened**: added `go vet` and `-race` flag to test workflow.
- **README rewritten**: badges, features, quick start, config examples, auth delegation, observability, roadmap, contributing.

## Test plan
- [x] `go test -race ./internal/...` passes (0 race conditions)
- [x] All 102 test cases pass
- [x] `go vet ./...` clean