### PR TITLE
feat(auth): RS256/JWKS support + documentation rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ make e2e
 - [x] Circuit breaker
 - [x] WebSocket support
 - [x] Hot config reload (SIGHUP)
-- [ ] JWT with RS256 / JWK
+- [x] JWT with RS256 / JWK (via JWKS endpoint)
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/aguiar-sh/tainha
 go 1.23.2
 
 require (
+	github.com/MicahParks/keyfunc/v2 v2.1.0
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/gorilla/mux v1.8.1
 	github.com/prometheus/client_golang v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/MicahParks/keyfunc/v2 v2.1.0 h1:6ZXKb9Rp6qp1bDbJefnG7cTH8yMN1IC/4nf+GVjO99k=
+github.com/MicahParks/keyfunc/v2 v2.1.0/go.mod h1:rW42fi+xgLJ2FRRXAfNx9ZA8WpD4OeE/yHVMteCkw9k=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=

--- a/internal/auth/jwks.go
+++ b/internal/auth/jwks.go
@@ -1,0 +1,78 @@
+package auth
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/MicahParks/keyfunc/v2"
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// ValidateJWKS validates JWT tokens using a remote JWKS endpoint.
+// Supports RS256, RS384, RS512, ES256, ES384, ES512, and other asymmetric algorithms.
+func ValidateJWKS(jwksURL string, next http.Handler) http.Handler {
+	jwks, err := keyfunc.Get(jwksURL, keyfunc.Options{})
+	if err != nil {
+		slog.Error("failed to fetch JWKS", "url", jwksURL, "error", err)
+		// Return handler that always rejects — don't crash the gateway
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			jsonError(w, "Auth configuration error", http.StatusInternalServerError)
+		})
+	}
+
+	slog.Info("JWKS loaded", "url", jwksURL)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := r.Header.Get(HeaderAuthorization)
+		if authHeader == "" {
+			jsonError(w, "Authorization header required", http.StatusUnauthorized)
+			return
+		}
+
+		bearerToken := strings.Split(authHeader, " ")
+		if len(bearerToken) != 2 || strings.ToLower(bearerToken[0]) != "bearer" {
+			jsonError(w, "Invalid authorization header format", http.StatusUnauthorized)
+			return
+		}
+
+		token, err := jwt.Parse(bearerToken[1], jwks.Keyfunc)
+		if err != nil || !token.Valid {
+			jsonError(w, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		if claims, ok := token.Claims.(jwt.MapClaims); ok {
+			if issuer := r.Header.Get(HeaderJWTIssuer); issuer != "" {
+				claimIssuer, ok := claims["iss"].(string)
+				if !ok || claimIssuer != issuer {
+					jsonError(w, "Invalid issuer", http.StatusUnauthorized)
+					return
+				}
+			}
+
+			if audience := r.Header.Get(HeaderJWTAudience); audience != "" {
+				claimAud, ok := claims["aud"].(string)
+				if !ok || claimAud != audience {
+					jsonError(w, "Invalid audience", http.StatusUnauthorized)
+					return
+				}
+			}
+
+			caser := cases.Title(language.Und)
+			for key, value := range claims {
+				if str, ok := value.(string); ok {
+					headerKey := HeaderPrefix + caser.String(key)
+					r.Header.Set(headerKey, str)
+				}
+			}
+		}
+
+		r.Header.Del(HeaderJWTIssuer)
+		r.Header.Del(HeaderJWTAudience)
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ type AuthConfig struct {
 	DefaultProtected bool   `yaml:"defaultProtected" mapstructure:"defaultProtected"`
 	AuthService      string `yaml:"authService" mapstructure:"authService"`
 	AuthPath         string `yaml:"authPath" mapstructure:"authPath"`
+	JwksURL          string `yaml:"jwksUrl" mapstructure:"jwksUrl"`
+	Algorithm        string `yaml:"algorithm" mapstructure:"algorithm"`
 }
 
 type RateLimitConfig struct {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -21,6 +21,25 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// wrapAuth wraps a handler with the appropriate auth middleware based on config.
+func wrapAuth(cfg *config.Config, handler http.Handler) http.Handler {
+	authCfg := cfg.BaseConfig.Auth
+	if authCfg.AuthService != "" {
+		authPath := authCfg.AuthPath
+		if authPath == "" {
+			authPath = "/validate"
+		}
+		_, authProtocol := util.PathProtocol(authCfg.AuthService)
+		authHost, _ := util.PathProtocol(authCfg.AuthService)
+		authURL := fmt.Sprintf("%s://%s%s", authProtocol, authHost, authPath)
+		return auth.ValidateWithService(authURL, handler)
+	}
+	if authCfg.JwksURL != "" {
+		return auth.ValidateJWKS(authCfg.JwksURL, handler)
+	}
+	return auth.ValidateJWT(authCfg.Secret, handler)
+}
+
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
@@ -101,18 +120,7 @@ func SetupRouter(cfg *config.Config) (*mux.Router, error) {
 		if route.IsWebSocket {
 			wsHandler := proxy.WebSocketProxy(path)
 			if cfg.BaseConfig.Auth.DefaultProtected && !route.Public {
-				if cfg.BaseConfig.Auth.AuthService != "" {
-					authPath := cfg.BaseConfig.Auth.AuthPath
-					if authPath == "" {
-						authPath = "/validate"
-					}
-					_, authProtocol := util.PathProtocol(cfg.BaseConfig.Auth.AuthService)
-					authHost, _ := util.PathProtocol(cfg.BaseConfig.Auth.AuthService)
-					authURL := fmt.Sprintf("%s://%s%s", authProtocol, authHost, authPath)
-					r.Handle(fullPath, auth.ValidateWithService(authURL, wsHandler)).Methods("GET")
-				} else {
-					r.Handle(fullPath, auth.ValidateJWT(cfg.BaseConfig.Auth.Secret, wsHandler)).Methods("GET")
-				}
+				r.Handle(fullPath, wrapAuth(cfg, wsHandler)).Methods("GET")
 			} else {
 				r.Handle(fullPath, wsHandler).Methods("GET")
 			}
@@ -253,18 +261,7 @@ func SetupRouter(cfg *config.Config) (*mux.Router, error) {
 		}
 
 		if cfg.BaseConfig.Auth.DefaultProtected && !route.Public {
-			if cfg.BaseConfig.Auth.AuthService != "" {
-				authPath := cfg.BaseConfig.Auth.AuthPath
-				if authPath == "" {
-					authPath = "/validate"
-				}
-				_, authProtocol := util.PathProtocol(cfg.BaseConfig.Auth.AuthService)
-				authHost, _ := util.PathProtocol(cfg.BaseConfig.Auth.AuthService)
-				authURL := fmt.Sprintf("%s://%s%s", authProtocol, authHost, authPath)
-				handler = auth.ValidateWithService(authURL, handler).ServeHTTP
-			} else {
-				handler = auth.ValidateJWT(cfg.BaseConfig.Auth.Secret, handler).ServeHTTP
-			}
+			handler = wrapAuth(cfg, handler).ServeHTTP
 		}
 
 		r.Handle(fullPath, handler).Methods(route.Method, "OPTIONS")

--- a/website/docs/authentication/index.md
+++ b/website/docs/authentication/index.md
@@ -5,26 +5,35 @@ slug: /authentication
 
 # Authentication
 
-Tainha supports two authentication modes:
+Tainha supports three authentication modes:
 
-1. **[Local JWT](/docs/authentication/local-jwt)** — the gateway validates tokens directly using a shared secret (HS256)
-2. **[Auth Delegation](/docs/authentication/delegation)** — the gateway delegates validation to your own auth service
+1. **[Local JWT (HS256)](/docs/authentication/local-jwt)** — validate tokens with a shared secret
+2. **[JWKS (RS256/ES256)](/docs/authentication/jwks)** — validate tokens with public keys from a JWKS endpoint
+3. **[Auth Delegation](/docs/authentication/delegation)** — delegate validation to your own auth service
 
-Both modes protect routes marked as non-public and forward user claims as headers to your backend services.
+All modes protect routes marked as non-public and forward user claims as `X-` headers to your backend services.
 
 ## Quick Comparison
 
-| | Local JWT | Auth Delegation |
-|---|---|---|
-| **Setup** | Just a secret in config | Requires running auth service |
-| **Algorithms** | HS256 only | Any (your service decides) |
-| **Performance** | Faster (no network call) | Extra hop per request |
-| **Flexibility** | Limited to JWT claims | Full control over validation |
-| **Use case** | Simple apps, prototyping | Production, custom auth |
+| | Local JWT | JWKS | Auth Delegation |
+|---|---|---|---|
+| **Setup** | Secret in config | JWKS URL in config | Running auth service |
+| **Algorithms** | HS256 | RS256, ES256, etc. | Any |
+| **Performance** | Fastest | Fast (keys cached) | Extra hop per request |
+| **Providers** | Custom | Auth0, Keycloak, Firebase, Cognito | Any |
+| **Use case** | Prototyping, simple apps | Standard identity providers | Full custom auth |
+
+## Priority
+
+If multiple options are configured:
+
+```
+authService > jwksUrl > secret
+```
 
 ## Public Routes
 
-Both modes respect the `public` flag. Mark routes as `public: true` to skip authentication entirely:
+Mark routes as `public: true` to skip authentication:
 
 ```yaml
 routes:
@@ -32,22 +41,24 @@ routes:
     route: /products
     service: localhost:3000
     path: /products
-    public: true          # No token required
+    public: true
 
   - method: GET
     route: /orders
     service: localhost:3000
     path: /orders
-    # public: false       # Token required (default)
+    # requires auth (default)
 ```
 
 ## Claim Forwarding
 
-In both modes, authenticated user data is forwarded to your backend as `X-` headers. Your backend reads these headers to identify the user — no need to parse the token again.
+In all modes, string claims are forwarded to your backend as `X-` headers:
 
-| Source Claim | Forwarded Header |
+| JWT Claim | Forwarded Header |
 |-----------|-----------------|
 | `username` | `X-Username` |
 | `role` | `X-Role` |
 | `sub` | `X-Sub` |
 | `email` | `X-Email` |
+
+Your backend reads these headers to identify the user — no need to parse the token again.

--- a/website/docs/authentication/jwks.md
+++ b/website/docs/authentication/jwks.md
@@ -1,0 +1,110 @@
+---
+sidebar_position: 3
+slug: /authentication/jwks
+---
+
+# JWT with RS256 / JWKS
+
+Validate JWT tokens using asymmetric algorithms (RS256, ES256, etc.) via a remote JWKS (JSON Web Key Set) endpoint. This is the standard for identity providers like Auth0, Keycloak, Firebase, AWS Cognito, and Okta.
+
+## Configuration
+
+```yaml
+config:
+  auth:
+    jwksUrl: "https://your-provider.com/.well-known/jwks.json"
+    defaultProtected: true
+```
+
+That's it. The gateway fetches the JWKS on startup and uses it to validate token signatures. No shared secret needed.
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant G as Gateway
+    participant J as JWKS Endpoint
+    participant B as Backend
+
+    Note over G,J: On startup
+    G->>J: GET /.well-known/jwks.json
+    J-->>G: Public keys (RSA/EC)
+
+    Note over C,B: Per request
+    C->>G: GET /api/users<br/>Authorization: Bearer xxx
+    G->>G: Validate signature with public key
+    G->>G: Extract claims
+    G->>B: GET /users<br/>X-Username: alice
+    B-->>G: 200 OK
+    G-->>C: 200 OK
+```
+
+1. On startup, the gateway fetches public keys from the JWKS URL
+2. For each request, validates the token signature using the matching key (by `kid` header)
+3. Extracts claims and forwards them as `X-` headers
+4. Supports key rotation — the gateway handles `kid` matching automatically
+
+## Supported Algorithms
+
+| Algorithm | Type | Use Case |
+|-----------|------|----------|
+| RS256 | RSA | Most common, Auth0/Keycloak default |
+| RS384 | RSA | Higher security RSA |
+| RS512 | RSA | Maximum security RSA |
+| ES256 | ECDSA | Compact keys, modern providers |
+| ES384 | ECDSA | Higher security ECDSA |
+| ES512 | ECDSA | Maximum security ECDSA |
+
+## Provider Examples
+
+### Auth0
+
+```yaml
+auth:
+  jwksUrl: "https://YOUR_DOMAIN.auth0.com/.well-known/jwks.json"
+  defaultProtected: true
+```
+
+### Keycloak
+
+```yaml
+auth:
+  jwksUrl: "https://keycloak.example.com/realms/YOUR_REALM/protocol/openid-connect/certs"
+  defaultProtected: true
+```
+
+### Firebase
+
+```yaml
+auth:
+  jwksUrl: "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com"
+  defaultProtected: true
+```
+
+### AWS Cognito
+
+```yaml
+auth:
+  jwksUrl: "https://cognito-idp.REGION.amazonaws.com/POOL_ID/.well-known/jwks.json"
+  defaultProtected: true
+```
+
+## Issuer and Audience Validation
+
+Same as local JWT — use request headers to trigger validation:
+
+| Header | Validates |
+|--------|-----------|
+| `X-JWT-Issuer` | Checks the `iss` claim |
+| `X-JWT-Audience` | Checks the `aud` claim |
+
+## Auth Mode Priority
+
+If multiple auth options are configured, Tainha uses this priority:
+
+1. **Auth Delegation** (`authService`) — highest priority
+2. **JWKS** (`jwksUrl`) — used if no authService
+3. **Local HS256** (`secret`) — fallback
+
+This means you can set both `secret` (for development) and `jwksUrl` (for production) — JWKS takes precedence.

--- a/website/docs/configuration.md
+++ b/website/docs/configuration.md
@@ -11,37 +11,60 @@ Tainha is configured through a single YAML file. By default, it looks for `./con
 ./tainha -config /path/to/config.yaml
 ```
 
+Send `SIGHUP` to reload config without restarting:
+
+```bash
+kill -HUP $(pgrep tainha)
+```
+
 ## Full Reference
 
 ```yaml
 config:
-  port: 8000                        # Gateway listen port
-  basePath: /api                    # Prefix for all routes
-  readTimeoutSec: 15                # Server read timeout
-  writeTimeoutSec: 30               # Server write timeout
-  idleTimeoutSec: 60                # Server idle timeout
+  port: 8000
+  basePath: /api
+  readTimeoutSec: 15
+  writeTimeoutSec: 30
+  idleTimeoutSec: 60
+
   auth:
-    secret: "your-secret-key"       # JWT signing secret (HS256)
-    defaultProtected: true          # Require auth on all routes by default
-    authService: localhost:5000     # (Optional) External auth service
-    authPath: /auth/validate        # (Optional) Auth service endpoint
+    secret: "your-secret-key"       # HS256 shared secret
+    jwksUrl: "https://.../.well-known/jwks.json"  # RS256/ES256 via JWKS
+    algorithm: RS256                # Algorithm hint (optional)
+    defaultProtected: true
+    authService: localhost:5000     # Or delegate to your own service
+    authPath: /auth/validate
+
   rateLimit:
-    enabled: true                   # Enable rate limiting
-    requestsPerSec: 100             # Requests per second per IP
-    burst: 200                      # Burst allowance
+    enabled: true
+    requestsPerSec: 100
+    burst: 200
+
+  mappingCache:
+    enabled: true
+    ttlSec: 60
+    maxSize: 1000
+
+  circuitBreaker:
+    enabled: true
+    maxFailures: 5
+    timeoutSec: 30
+    halfOpenRequests: 1
+
   telemetry:
-    enabled: true                   # Enable OTEL metrics + traces
-    serviceName: tainha-gateway     # Service name in traces
-    exporterEndpoint: localhost:4317 # OTLP gRPC endpoint
+    enabled: true
+    serviceName: tainha-gateway
+    exporterEndpoint: localhost:4317
 
 routes:
-  - method: GET                     # HTTP method
-    route: /products                # Client-facing path (gateway)
-    service: localhost:3000         # Backend service host
-    path: /products                 # Backend endpoint path
-    public: true                    # Override auth (skip validation)
-    isSSE: false                    # Enable SSE streaming
-    mapping:                        # Response enrichment (optional)
+  - method: GET
+    route: /products
+    service: localhost:3000
+    path: /products
+    public: true
+    isSSE: false
+    isWebSocket: false
+    mapping:
       - path: /categories?id={categoryId}
         service: localhost:3000
         tag: category
@@ -54,17 +77,53 @@ routes:
 |-------|------|---------|-------------|
 | `port` | int | `8080` | Port the gateway listens on |
 | `basePath` | string | `/api` | Prefix prepended to all route paths |
-| `auth.secret` | string | — | HMAC secret for local JWT validation |
-| `auth.defaultProtected` | bool | `false` | Whether routes require auth by default |
-| `auth.authService` | string | — | External auth service host (enables delegation) |
-| `auth.authPath` | string | `/validate` | Endpoint path on the auth service |
-| `rateLimit.enabled` | bool | `false` | Enable per-IP rate limiting |
-| `rateLimit.requestsPerSec` | int | `100` | Max requests per second per IP |
-| `rateLimit.burst` | int | `requestsPerSec * 2` | Burst allowance |
 | `readTimeoutSec` | int | `15` | HTTP server read timeout |
 | `writeTimeoutSec` | int | `30` | HTTP server write timeout |
 | `idleTimeoutSec` | int | `60` | HTTP server idle timeout |
-| `telemetry.enabled` | bool | `false` | Enable OpenTelemetry metrics and traces |
+
+### Auth
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `auth.secret` | string | — | HMAC secret for HS256 validation |
+| `auth.jwksUrl` | string | — | JWKS endpoint URL for RS256/ES256 |
+| `auth.algorithm` | string | — | Algorithm hint (optional) |
+| `auth.defaultProtected` | bool | `false` | Require auth on all routes by default |
+| `auth.authService` | string | — | External auth service (enables delegation) |
+| `auth.authPath` | string | `/validate` | Auth service endpoint path |
+
+**Priority:** `authService` > `jwksUrl` > `secret`. Only one is used.
+
+### Rate Limiting
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rateLimit.enabled` | bool | `false` | Enable per-IP rate limiting |
+| `rateLimit.requestsPerSec` | int | `100` | Max requests per second per IP |
+| `rateLimit.burst` | int | `requestsPerSec * 2` | Burst allowance |
+
+### Mapping Cache
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `mappingCache.enabled` | bool | `false` | Cache mapping responses |
+| `mappingCache.ttlSec` | int | `60` | Time-to-live in seconds |
+| `mappingCache.maxSize` | int | `1000` | Max cached entries (LRU eviction) |
+
+### Circuit Breaker
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `circuitBreaker.enabled` | bool | `false` | Enable per-service circuit breaker |
+| `circuitBreaker.maxFailures` | int | `5` | Failures before opening circuit |
+| `circuitBreaker.timeoutSec` | int | `30` | Seconds before trying half-open |
+| `circuitBreaker.halfOpenRequests` | int | `1` | Probe requests in half-open state |
+
+### Telemetry
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `telemetry.enabled` | bool | `false` | Enable OTEL metrics + traces |
 | `telemetry.serviceName` | string | `tainha-gateway` | Service name in OTEL |
 | `telemetry.exporterEndpoint` | string | — | OTLP gRPC endpoint for traces |
 
@@ -72,12 +131,13 @@ routes:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `method` | string | — | HTTP method (GET, POST, PUT, DELETE) |
+| `method` | string | — | HTTP method (GET, POST, PUT, DELETE, PATCH) |
 | `route` | string | — | Gateway path (what clients hit) |
 | `service` | string | — | Backend host (with or without protocol) |
 | `path` | string | — | Backend path (supports `{param}` placeholders) |
 | `public` | bool | `false` | Skip authentication for this route |
 | `isSSE` | bool | `false` | Enable SSE passthrough |
+| `isWebSocket` | bool | `false` | Enable WebSocket proxy |
 | `mapping` | array | — | Response mapping rules |
 
 ## Route Mapping
@@ -96,62 +156,15 @@ Both `route` and `path` support dynamic parameters with `{paramName}` syntax:
 ```yaml
 routes:
   - method: GET
-    route: /users/{userId}          # Client hits /api/users/42
+    route: /users/{userId}
     service: localhost:3000
-    path: /users/{userId}           # Proxied to backend as /users/42
+    path: /users/{userId}
 ```
 
 ## Service URLs
 
-The `service` field accepts URLs with or without protocol:
-
 ```yaml
-# All valid:
 service: localhost:3000             # Defaults to http://
 service: http://localhost:3000
 service: https://api.example.com
-```
-
-## Examples
-
-### Simple proxy
-
-```yaml
-routes:
-  - method: GET
-    route: /products
-    service: localhost:3000
-    path: /products
-    public: true
-```
-
-### Protected route with path params
-
-```yaml
-routes:
-  - method: GET
-    route: /users/{userId}
-    service: localhost:3000
-    path: /users/{userId}
-    # public: false (default — requires JWT)
-```
-
-### Route with response mapping
-
-```yaml
-routes:
-  - method: GET
-    route: /posts
-    service: localhost:3000
-    path: /posts
-    public: true
-    mapping:
-      - path: /comments?postId={id}
-        service: localhost:3000
-        tag: comments
-        removeKeyMapping: false
-      - path: /users/{userId}
-        service: localhost:3000
-        tag: author
-        removeKeyMapping: true
 ```

--- a/website/docs/resilience.md
+++ b/website/docs/resilience.md
@@ -1,0 +1,123 @@
+---
+sidebar_position: 7
+slug: /resilience
+---
+
+# Resilience
+
+Tainha includes built-in features to keep your gateway stable under failure conditions.
+
+## Circuit Breaker
+
+Prevents cascading failures when a backend service goes down. Instead of waiting for timeouts on every request, the circuit breaker detects failures and rejects requests immediately.
+
+### How It Works
+
+```mermaid
+stateDiagram-v2
+    [*] --> Closed
+    Closed --> Open : maxFailures reached
+    Open --> HalfOpen : timeout elapsed
+    HalfOpen --> Closed : probe succeeds
+    HalfOpen --> Open : probe fails
+```
+
+| State | Behavior |
+|-------|----------|
+| **Closed** | Normal operation, requests pass through |
+| **Open** | Requests rejected with 503 immediately |
+| **Half-Open** | Allows N probe requests to test recovery |
+
+### Configuration
+
+```yaml
+config:
+  circuitBreaker:
+    enabled: true
+    maxFailures: 5        # 5xx responses before opening
+    timeoutSec: 30        # Seconds before trying half-open
+    halfOpenRequests: 1   # Probe requests to test recovery
+```
+
+### Per-Service Isolation
+
+Each backend service has its own circuit. If `service-A` goes down, requests to `service-B` are unaffected.
+
+## Mapping Cache
+
+Caches responses from mapping requests to avoid redundant HTTP calls. If multiple response items reference the same mapped resource, it's fetched once.
+
+### Configuration
+
+```yaml
+config:
+  mappingCache:
+    enabled: true
+    ttlSec: 60          # Cache entries expire after 60s
+    maxSize: 1000       # Max entries (LRU eviction when full)
+```
+
+### How It Works
+
+```mermaid
+flowchart TD
+    A[Mapping request for URL] --> B{In cache?}
+    B -->|Yes, not expired| C[Return cached data]
+    B -->|No / expired| D[Fetch from service]
+    D --> E[Store in cache]
+    E --> C
+```
+
+- Cache key is the full mapped URL (e.g., `http://service:3000/categories?id=1`)
+- Expired entries are cleaned up in background every 30 seconds
+- When cache is full, the oldest entry is evicted (LRU)
+
+### When to Use
+
+- Mapping targets that don't change often (categories, configs, user profiles)
+- High-traffic routes with many items that share the same mapped resources
+- Reducing load on downstream services
+
+## Rate Limiting
+
+Token bucket rate limiter per client IP with `X-Forwarded-For` awareness.
+
+```yaml
+config:
+  rateLimit:
+    enabled: true
+    requestsPerSec: 100
+    burst: 200
+```
+
+Returns `429 Too Many Requests` with `Retry-After: 1` header when limit is exceeded.
+
+## Server Timeouts
+
+Prevent slow clients or backends from holding connections indefinitely.
+
+```yaml
+config:
+  readTimeoutSec: 15    # Max time to read request
+  writeTimeoutSec: 30   # Max time to write response
+  idleTimeoutSec: 60    # Max time for idle keep-alive connections
+```
+
+## Graceful Shutdown
+
+On `SIGTERM` or `SIGINT`, the gateway:
+1. Stops accepting new connections
+2. Waits up to 15 seconds for in-flight requests to complete
+3. Shuts down cleanly
+
+## Hot Config Reload
+
+Reload configuration without downtime:
+
+```bash
+kill -HUP $(pgrep tainha)
+```
+
+- Routes are swapped atomically (zero dropped requests)
+- If the new config is invalid, the current config stays active
+- Cache and rate limiter state are preserved across reloads

--- a/website/docs/websocket.md
+++ b/website/docs/websocket.md
@@ -1,0 +1,76 @@
+---
+sidebar_position: 8
+slug: /websocket
+---
+
+# WebSocket Support
+
+Tainha proxies WebSocket connections to backend services. When a route is marked as `isWebSocket: true`, the gateway handles the HTTP upgrade and establishes a bidirectional TCP tunnel.
+
+## Configuration
+
+```yaml
+routes:
+  - method: GET
+    route: /ws
+    service: localhost:3001
+    path: /ws
+    isWebSocket: true
+    public: true
+```
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant G as Gateway
+    participant B as Backend
+
+    C->>G: GET /api/ws (Upgrade: websocket)
+    G->>B: Forward upgrade request
+    B-->>G: 101 Switching Protocols
+    G-->>C: 101 Switching Protocols
+    Note over C,B: Bidirectional TCP tunnel
+    C->>G: WebSocket frame
+    G->>B: WebSocket frame
+    B->>G: WebSocket frame
+    G->>C: WebSocket frame
+```
+
+1. Client sends an HTTP request with `Upgrade: websocket`
+2. Gateway hijacks the connection and connects to the backend
+3. Original upgrade request is forwarded to the backend
+4. Bytes are piped bidirectionally until either side closes
+
+## Authentication
+
+WebSocket routes support authentication. The token is validated during the HTTP upgrade — before the WebSocket connection is established.
+
+```yaml
+routes:
+  - method: GET
+    route: /ws/chat
+    service: localhost:3001
+    path: /chat
+    isWebSocket: true
+    # public: false → requires auth token in upgrade request
+```
+
+The client sends the JWT in the initial upgrade request:
+
+```javascript
+const ws = new WebSocket('ws://gateway:8000/api/ws/chat', [], {
+  headers: { 'Authorization': 'Bearer <token>' }
+});
+```
+
+## Differences from SSE
+
+| | WebSocket | SSE |
+|---|---|---|
+| Direction | Bidirectional | Server → Client only |
+| Protocol | WebSocket (TCP tunnel) | HTTP (text/event-stream) |
+| Config | `isWebSocket: true` | `isSSE: true` |
+| Response mapping | Not supported | Not supported |
+| Use case | Chat, games, real-time collaboration | Notifications, feeds, dashboards |

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -10,11 +10,14 @@ const sidebars: SidebarsConfig = {
       link: {type: 'doc', id: 'authentication/index'},
       items: [
         'authentication/local-jwt',
+        'authentication/jwks',
         'authentication/delegation',
       ],
     },
     'response-mapping',
     'sse',
+    'websocket',
+    'resilience',
     'observability',
   ],
 };


### PR DESCRIPTION
## Summary

### RS256/JWKS Authentication
- Validate JWT tokens via remote JWKS endpoints — works out of the box with Auth0, Keycloak, Firebase, AWS Cognito
- Supports RS256, RS384, RS512, ES256, ES384, ES512
- Auto key matching by `kid` header, handles key rotation
```yaml
auth:
  jwksUrl: "https://your-provider.com/.well-known/jwks.json"
  defaultProtected: true
```

### Router Refactor
- Extracted `wrapAuth()` helper — eliminates duplicated auth wiring across regular, SSE, and WebSocket route handlers

### Documentation Rewrite
New and updated pages:
- **Configuration** — complete reference for all config fields (auth, rateLimit, mappingCache, circuitBreaker, telemetry)
- **JWKS** — new page with provider examples, algorithm table, flow diagram
- **Auth Index** — updated for 3 modes with comparison table and priority explanation
- **Resilience** — new page covering circuit breaker (state diagram), mapping cache, rate limiting, timeouts, graceful shutdown, hot reload
- **WebSocket** — new page with flow diagram, auth integration, SSE comparison

Sidebar: auth (3 sub-pages), response mapping, SSE, WebSocket, resilience, observability

### Roadmap
All items completed — no remaining unchecked items.

## Test plan
- [x] `go test -race ./internal/...` — all pass
- [x] `go build ./...` — clean
- [x] Docs site builds successfully